### PR TITLE
docs: add project roadmap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Content-Type: application/json
 
 See [docs/development.md](docs/development.md) for setup instructions.
 
+## Roadmap
+
+See [docs/roadmap.md](docs/roadmap.md) for project milestones and future plans.
+
 ## License
 
 [MIT License](LICENSE)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,11 @@
+# Roadmap
+
+## v0.4.0
+- Repository abstraction improvements
+- CLI interface
+
+## v0.5.0
+- Persistence layer (PostgreSQL)
+
+## v1.0.0
+- Production-ready governance analysis pipeline


### PR DESCRIPTION
## Summary
- Add docs/roadmap.md with project version planning
- Outline v0.4.0, v0.5.0, and v1.0.0 milestones